### PR TITLE
Bump sspi-rs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0 - TBD
 
 + Require Python 3.9 or newer (dropped 3.8)
++ Update `sspi-rs` to `0.15.4`
 
 ## 0.2.0 - 2024-10-03
 

--- a/build_helpers/cibuildwheel-before-all.sh
+++ b/build_helpers/cibuildwheel-before-all.sh
@@ -3,7 +3,7 @@ set -ex
 # sspi-rs doesn't have versions, this just needs to be bumped when new changes
 # are needed.
 # https://github.com/Devolutions/sspi-rs
-DEVOLUTIONS_COMMIT_ID="98e34308377877a6601a07f39da8c329a1e6b08e"
+DEVOLUTIONS_COMMIT_ID="d7b9ff6ffd2157c2f40953c5afc645a7ae203a1e"
 
 # Aligns to a release on https://github.com/unicode-org/icu/tree/main
 ICU_VERSION="73.2"


### PR DESCRIPTION
Bumps the bundled version of sspi-rs for macOS/Linux to 0.15.4 which includes new features like DCE/RPC support and other fixes.