### PR TITLE
Pin Cython and update build info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     name: build sdist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
 
     - name: build sdist
       run: |
@@ -46,6 +46,12 @@ jobs:
       matrix:
         include:
         - os: macOS-13
+          version: cp314-macosx_x86_64
+          prerelease: true
+        - os: macOS-14
+          version: cp314-macosx_arm64
+          prerelease: true
+        - os: macOS-13
           version: cp313-macosx_x86_64
         - os: macOS-14
           version: cp313-macosx_arm64
@@ -67,6 +73,9 @@ jobs:
           version: cp39-macosx_arm64
 
         - os: ubuntu-latest
+          version: cp314-manylinux_x86_64
+          prerelease: true
+        - os: ubuntu-latest
           version: cp313-manylinux_x86_64
         - os: ubuntu-latest
           version: cp312-manylinux_x86_64
@@ -78,38 +87,47 @@ jobs:
           version: cp39-manylinux_x86_64
 
         - os: windows-2022
-          version: cp313-win_amd64
+          version: cp314-win_amd64
+          prerelease: true
+        - os: windows-11-arm
+          version: cp314-win_arm64
+          prerelease: true
         - os: windows-2022
+          version: cp314-win32
+          prerelease: true
+        - os: windows-2022
+          version: cp313-win_amd64
+        - os: windows-11-arm
           version: cp313-win_arm64
         - os: windows-2022
           version: cp313-win32
         - os: windows-2022
           version: cp312-win_amd64
-        - os: windows-2022
+        - os: windows-11-arm
           version: cp312-win_arm64
         - os: windows-2022
           version: cp312-win32
         - os: windows-2022
           version: cp311-win_amd64
-        - os: windows-2022
+        - os: windows-11-arm
           version: cp311-win_arm64
         - os: windows-2022
           version: cp311-win32
         - os: windows-2022
           version: cp310-win_amd64
-        - os: windows-2022
+        - os: windows-11-arm
           version: cp310-win_arm64
         - os: windows-2022
           version: cp310-win32
         - os: windows-2022
           version: cp39-win_amd64
-        - os: windows-2022
+        - os: windows-11-arm
           version: cp39-win_arm64
         - os: windows-2022
           version: cp39-win32
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         name: artifact-sdist
         path: ./
@@ -123,15 +141,12 @@ jobs:
         rm sspilib-*.tar.gz
 
     - name: build wheel
-      uses: pypa/cibuildwheel@v2.23.2
+      uses: pypa/cibuildwheel@v3.1.4
       env:
-        CIBW_ARCHS: ${{ fromJSON('["auto", "ARM64"]')[endsWith(matrix.version, '-win_arm64')] }}
-        CIBW_TEST_SKIP: '*-win_arm64'
         CIBW_BUILD: ${{ matrix.version }}
         CIBW_BUILD_VERBOSITY: 1
         CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease || 'false' }}
         MACOSX_DEPLOYMENT_TARGET: '10.12'  # rustc has a min on 10.12
-        SSPI_SKIP_MODULE_CHECK: ${{ fromJSON('["", "true"]')[endsWith(matrix.version, '-win_arm64')] }}
 
     - uses: actions/upload-artifact@v4
       with:
@@ -152,12 +167,14 @@ jobs:
         - macOS-latest
         - ubuntu-latest
         - windows-latest
+        - windows-11-arm
         python-version:
         - 3.9
         - '3.10'
         - '3.11'
         - '3.12'
         - '3.13'
+        - '3.14-dev'
         python-arch:
         - arm64
         - x86
@@ -166,6 +183,16 @@ jobs:
         exclude:
         - os: windows-latest
           python-arch: arm64
+        - os: windows-11-arm
+          python-arch: x86
+        - os: windows-11-arm
+          python-version: 3.9
+        - os: windows-11-arm
+          python-version: '3.10'
+        - os: windows-11-arm
+          python-version: '3.14-dev'
+        - os: windows-11-arm
+          python-arch: x64
         - os: ubuntu-latest
           python-arch: arm64
         - os: ubuntu-latest
@@ -176,14 +203,14 @@ jobs:
           python-arch: x64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-arch }}
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -212,7 +239,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v5
       with:
         pattern: artifact-*
         merge-multiple: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0 - TBD
+
++ Updated build requirements to track a more immutable release structure
++ Add Python 3.14 wheels and official support
++ Update `sspi-rs` to `0.16.1`
+
 ## 0.3.1 - 2025-05-01
 
 + Fix build requirements with correct `setuptools` minimum of `>=77.0.0`

--- a/build_helpers/cibuildwheel-before-all.sh
+++ b/build_helpers/cibuildwheel-before-all.sh
@@ -3,7 +3,7 @@ set -ex
 # sspi-rs doesn't have versions, this just needs to be bumped when new changes
 # are needed.
 # https://github.com/Devolutions/sspi-rs
-DEVOLUTIONS_COMMIT_ID="d7b9ff6ffd2157c2f40953c5afc645a7ae203a1e"
+DEVOLUTIONS_COMMIT_ID="7474617be07f2ee1952de6d0913c4fa64a61a354"
 
 # Aligns to a release on https://github.com/unicode-org/icu/tree/main
 ICU_VERSION="73.2"

--- a/build_helpers/lib.sh
+++ b/build_helpers/lib.sh
@@ -18,18 +18,13 @@ lib::setup::python_requirements() {
     fi
 
     echo "Installing sspilib"
-    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
-        DIST_LINK_PATH="$( echo "${PWD}/dist" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/' )"
-    else
-        DIST_LINK_PATH="${PWD}/dist"
-    fi
 
     # Getting the version is important so that pip prioritises our local dist
     python -m pip install build
     SSPI_VERSION="$( grep -m 1 version pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3 )"
 
     python -m pip install sspilib=="${SSPI_VERSION}" \
-        --find-links "file://${DIST_LINK_PATH}" \
+        --find-links dist \
         --verbose
 
     echo "Installing dev dependencies"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
 requires = [
-    "Cython >= 3.0.0, < 4.0.0",
-    "setuptools >= 77.0.0", # license and license-files alignment
+    "Cython == 3.1.3",
+    "setuptools >= 77.0.3", # license and license-files alignment
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "sspilib"
-version = "0.3.1"
+version = "0.4.0"
 description = "SSPI API bindings for Python"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -24,7 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 
 [project.urls]


### PR DESCRIPTION
Pins the version of Cython specified in the build requirements to provide more immutable builds across the release versions. Add official support for Python 3.14 including a wheel for the various platforms.