### PR TITLE
Add support for Free-Threading and Limited API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     name: build sdist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.13
 
@@ -30,7 +30,7 @@ jobs:
       env:
         SSPI_SKIP_EXTENSIONS: true
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: artifact-sdist
         path: ./dist/*.tar.gz
@@ -45,68 +45,53 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: macOS-13
-          version: cp314-macosx_x86_64
-          prerelease: true
-        - os: macOS-14
-          version: cp314-macosx_arm64
-          prerelease: true
-        - os: macOS-13
-          version: cp313-macosx_x86_64
-        - os: macOS-14
-          version: cp313-macosx_arm64
-        - os: macOS-13
-          version: cp312-macosx_x86_64
-        - os: macOS-14
-          version: cp312-macosx_arm64
-        - os: macOS-13
+        # Free-threading needs version specific
+        - os: macos-15-intel
+          version: cp314t-macosx_x86_64
+        - os: macos-15
+          version: cp314t-macosx_arm64
+        # 3.11+ can use the Limited API/Stable ABI
+        - os: macos-15-intel
           version: cp311-macosx_x86_64
-        - os: macOS-14
+        - os: macos-15
           version: cp311-macosx_arm64
-        - os: macOS-13
+        - os: macos-15-intel
           version: cp310-macosx_x86_64
-        - os: macOS-14
+        - os: macos-15
           version: cp310-macosx_arm64
-        - os: macOS-13
+        - os: macos-15-intel
           version: cp39-macosx_x86_64
-        - os: macOS-14
+        - os: macos-15
           version: cp39-macosx_arm64
 
+        # Free-threading needs version specific
         - os: ubuntu-latest
-          version: cp314-manylinux_x86_64
-          prerelease: true
-        - os: ubuntu-latest
-          version: cp313-manylinux_x86_64
-        - os: ubuntu-latest
-          version: cp312-manylinux_x86_64
+          version: cp314t-manylinux_x86_64
+        - os: ubuntu-22.04-arm
+          version: cp314t-manylinux_aarch64
+        # 3.11+ can use the Limited API/Stable ABI
         - os: ubuntu-latest
           version: cp311-manylinux_x86_64
+        - os: ubuntu-22.04-arm
+          version: cp311-manylinux_aarch64
         - os: ubuntu-latest
           version: cp310-manylinux_x86_64
+        - os: ubuntu-22.04-arm
+          version: cp310-manylinux_aarch64
         - os: ubuntu-latest
           version: cp39-manylinux_x86_64
+        - os: ubuntu-22.04-arm
+          version: cp39-manylinux_aarch64
 
+        # Free-threading needs version specific
         - os: windows-2022
-          version: cp314-win_amd64
-          prerelease: true
+          version: cp314t-win_amd64
         - os: windows-11-arm
-          version: cp314-win_arm64
-          prerelease: true
+          version: cp314t-win_arm64
         - os: windows-2022
-          version: cp314-win32
-          prerelease: true
-        - os: windows-2022
-          version: cp313-win_amd64
-        - os: windows-11-arm
-          version: cp313-win_arm64
-        - os: windows-2022
-          version: cp313-win32
-        - os: windows-2022
-          version: cp312-win_amd64
-        - os: windows-11-arm
-          version: cp312-win_arm64
-        - os: windows-2022
-          version: cp312-win32
+          version: cp314t-win32
+
+        # 3.11+ can use the Limited API/Stable ABI
         - os: windows-2022
           version: cp311-win_amd64
         - os: windows-11-arm
@@ -127,7 +112,7 @@ jobs:
           version: cp39-win32
 
     steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@v6
       with:
         name: artifact-sdist
         path: ./
@@ -141,14 +126,14 @@ jobs:
         rm sspilib-*.tar.gz
 
     - name: build wheel
-      uses: pypa/cibuildwheel@v3.1.4
+      uses: pypa/cibuildwheel@v3.3.0
       env:
         CIBW_BUILD: ${{ matrix.version }}
         CIBW_BUILD_VERBOSITY: 1
         CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease || 'false' }}
         MACOSX_DEPLOYMENT_TARGET: '10.12'  # rustc has a min on 10.12
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         path: ./wheelhouse/*.whl
         name: artifact-wheel-${{ matrix.version }}
@@ -164,8 +149,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macOS-latest
+        - macos-latest
         - ubuntu-latest
+        - ubuntu-22.04-arm
         - windows-latest
         - windows-11-arm
         python-version:
@@ -174,7 +160,8 @@ jobs:
         - '3.11'
         - '3.12'
         - '3.13'
-        - '3.14-dev'
+        - '3.14'
+        - '3.14t'
         python-arch:
         - arm64
         - x86
@@ -183,34 +170,41 @@ jobs:
         exclude:
         - os: windows-latest
           python-arch: arm64
+
         - os: windows-11-arm
           python-arch: x86
         - os: windows-11-arm
-          python-version: 3.9
+          python-arch: x64
+        # <= 3.10 is not available on arm64 Windows
+        - os: windows-11-arm
+          python-version: '3.9'
         - os: windows-11-arm
           python-version: '3.10'
-        - os: windows-11-arm
-          python-version: '3.14-dev'
-        - os: windows-11-arm
-          python-arch: x64
+
         - os: ubuntu-latest
           python-arch: arm64
         - os: ubuntu-latest
           python-arch: x86
-        - os: macOS-latest
+
+        - os: ubuntu-22.04-arm
           python-arch: x86
-        - os: macOS-latest
+        - os: ubuntu-22.04-arm
+          python-arch: x64
+
+        - os: macos-latest
+          python-arch: x86
+        - os: macos-latest
           python-arch: x64
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-arch }}
 
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@v6
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -224,7 +218,7 @@ jobs:
 
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: Unit Test Results (${{ matrix.os }} ${{ matrix.python-version }}) ${{ matrix.python-arch }}
         path: ./junit/test-results.xml
@@ -239,7 +233,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/download-artifact@v5
+    - uses: actions/download-artifact@v6
       with:
         pattern: artifact-*
         merge-multiple: true

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ ENV/
 
 # poetry
 poetry.lock
+
+uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.0 - TBD
+
++ Build using the Stable ABI/Limited API with Python 3.11 and newer
++ Updated Cython build requirements to `3.2.1`
++ Added support for Python free-threading (`PEP 779`)
+  + PyPI will contain wheels for Python 3.14t and newer versions as they are released
+  + Python 3.13t is not supported or tested so may or may not work
++ Update `sspi-rs` to `0.18.4`
+  + Update `icu` used with `sspi-rs` on non-Windows to `78.1`
+
 ## 0.4.0 - 2025-09-01
 
 + Updated build requirements to track a more immutable release structure

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The interface for `sspi-rs` is exactly the same as SSPI on Windows so the same c
 In saying this, compatibility with SSPI actual is not 100% there so use at your own risk.
 
 It is recommended to use a library that wraps GSSAPI on non-Windows platforms like [python-gssapi](https://github.com/pythongssapi/python-gssapi).
-There is no support for any other architectures on Linux except `x86_64` and as `sspi-rs` only supports glibc it cannot be used with musl based distributions like Alpine.
+There is no support for any other architectures on Linux except `x86_64` and `aarch64` (ARM64), and as `sspi-rs` only supports glibc it cannot be used with musl based distributions like Alpine.
 
 ## Python Free-Threading (PEP 779)
 

--- a/README.md
+++ b/README.md
@@ -125,3 +125,11 @@ In saying this, compatibility with SSPI actual is not 100% there so use at your 
 
 It is recommended to use a library that wraps GSSAPI on non-Windows platforms like [python-gssapi](https://github.com/pythongssapi/python-gssapi).
 There is no support for any other architectures on Linux except `x86_64` and as `sspi-rs` only supports glibc it cannot be used with musl based distributions like Alpine.
+
+## Python Free-Threading (PEP 779)
+
+This library supports Python Free-Threading and will build free-threading-compatible extension files if installed under a free-threading interpreter.
+Python 3.14t is tested in CI and a wheel will be created for 3.14t+.
+Python 3.13t is not officially tested or supported but may or may not work.
+There is limited testing for free-threading in this library and it does not aim to be thread safe out of the box.
+If you encounter any issues or problems with this scenario please raise an issue and we can look at possible options to fix this.

--- a/build_helpers/cibuildwheel-before-all.sh
+++ b/build_helpers/cibuildwheel-before-all.sh
@@ -3,10 +3,10 @@ set -ex
 # sspi-rs doesn't have versions, this just needs to be bumped when new changes
 # are needed.
 # https://github.com/Devolutions/sspi-rs
-DEVOLUTIONS_COMMIT_ID="7474617be07f2ee1952de6d0913c4fa64a61a354"
+DEVOLUTIONS_COMMIT_ID="96092892fb5b93e06393c5ca01abf91d9e3871b0"
 
 # Aligns to a release on https://github.com/unicode-org/icu/tree/main
-ICU_VERSION="73.2"
+ICU_VERSION="78.1"
 ICU_CONFIGURE_FLAGS=(
     "--enable-static=yes"
     "--enable-shared=no"
@@ -31,7 +31,7 @@ if [ "$( uname )" == "Darwin" ]; then
     LIB_EXT="dylib"
     CPUS="$( sysctl -n hw.ncpu )"
 
-    ICU_CXXFLAGS="-stdlib=libc++ -std=c++11"
+    ICU_CXXFLAGS="-stdlib=libc++ -std=c++17"
 else
     LIB_EXT="so"
     CPUS="$( nproc )"
@@ -47,10 +47,10 @@ fi
 wget \
     --no-verbose \
     --directory-prefix="${SSPILIB_PATH}" \
-    "https://github.com/unicode-org/icu/releases/download/release-$( echo ${ICU_VERSION} | sed 's/\./-/' )/icu4c-$( echo ${ICU_VERSION} | sed 's/\./_/' )-src.tgz"
+    "https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION}/icu4c-${ICU_VERSION}-sources.tgz"
 
 tar -xf \
-    "${SSPILIB_PATH}"/icu4c-*-src.tgz \
+    "${SSPILIB_PATH}"/icu4c-${ICU_VERSION}-sources.tgz \
     -C "${SSPILIB_PATH}"
 
 mkdir -p "${SSPILIB_PATH}/icu-native"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
 requires = [
-    "Cython == 3.1.3",
+    "Cython == 3.2.1",
     "setuptools >= 77.0.3", # license and license-files alignment
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "sspilib"
-version = "0.4.0"
+version = "0.5.0"
 description = "SSPI API bindings for Python"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -25,7 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14"
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta"
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ import ctypes
 import os
 import pathlib
 import platform
+import sys
+import sysconfig
 import typing
 
 from Cython.Build import cythonize
@@ -18,6 +20,16 @@ SKIP_EXTENSIONS = os.environ.get("SSPI_SKIP_EXTENSIONS", "false").lower() == "tr
 SKIP_MODULE_CHECK = os.environ.get("SSPI_SKIP_MODULE_CHECK", "false").lower() == "true"
 CYTHON_LINETRACE = os.environ.get("SSPI_CYTHON_TRACING", "false").lower() == "true"
 SSPI_MAIN_LIB = os.environ.get("SSPI_MAIN_LIB", None)
+
+# Enable limited API for Python 3.11+
+USE_LIMITED_API = sys.version_info >= (3, 11)
+LIMITED_API_VERSION = 0x030B0000  # Python 3.11 ABI
+
+IS_FREE_THREADED = False
+if sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+    # Free-threaded Python does not support the limited API.
+    USE_LIMITED_API = False
+    IS_FREE_THREADED = True
 
 
 def make_extension(
@@ -77,6 +89,10 @@ if not SKIP_EXTENSIONS:
         print(f"Using {sspi_path} as SSPI module for platform checks")
         sspi = ctypes.CDLL(sspi_path)
 
+    if USE_LIMITED_API:
+        print(f"Building with Python Limited API (Py_LIMITED_API={hex(LIMITED_API_VERSION)}) for Stable ABI")
+        define_macros.append(("Py_LIMITED_API", LIMITED_API_VERSION))
+
     for e in [
         "context_attributes",
         "credential_attributes",
@@ -105,14 +121,25 @@ if not SKIP_EXTENSIONS:
             extra_compile_args=extra_compile_args,
             libraries=libraries,
             define_macros=define_macros,
+            py_limited_api=USE_LIMITED_API,
         )
         if ext:
             raw_extensions.append(ext)
+
+setup_options = {}
+if USE_LIMITED_API:
+    setup_options["bdist_wheel"] = {"py_limited_api": "cp311"}
+
+compiler_directives = {"linetrace": CYTHON_LINETRACE}
+if IS_FREE_THREADED:
+    # Enable free-threading support in Cython
+    compiler_directives["freethreading_compatible"] = True
 
 setup(
     ext_modules=cythonize(
         raw_extensions,
         language_level=3,
-        compiler_directives={"linetrace": CYTHON_LINETRACE},
+        compiler_directives=compiler_directives,
     ),
+    options=setup_options,
 )

--- a/src/sspilib/raw/python_sspi.h
+++ b/src/sspilib/raw/python_sspi.h
@@ -1,6 +1,7 @@
 #if defined(SSPILIB_IS_LINUX)
 // We need to redefine all the relevant entries in the Windows headers
 #include <stdint.h>
+#include <stdlib.h>
 
 // Windows.h
 typedef unsigned short WCHAR;


### PR DESCRIPTION
Adds build support for Python Free-Threading (PEP 779). Wheels will be created if installed under a free-threaded enabled interpreter.

Also adds support for building wheels with the Limited API/Stable ABI (PEP 652 and 697) for Python 3.11 and newer (non free-threaded).